### PR TITLE
Fixed missing "_" on the docker-compose ref in csproj

### DIFF
--- a/Bikesharing.Campaign/Bikesharing.Campaign.csproj
+++ b/Bikesharing.Campaign/Bikesharing.Campaign.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
-    <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
+    <DockerComposeProjectPath>..\_docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />


### PR DESCRIPTION
Project was building and running locally fine, but would not publish. Adding in the _ fixes publish, and the app still runs in the local container. 